### PR TITLE
Fix --callout-color for Obsidian 1.13+

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "PLN",
     "version": "1.18.1",
-    "minAppVersion": "1.7.7",
+    "minAppVersion": "1.13.0",
     "author": "PipeItToDevNull",
     "authorUrl": "https://docs.dev0.sh"
 }

--- a/theme.css
+++ b/theme.css
@@ -815,17 +815,17 @@ settings:
     --accent-dark-hsl-s: 34%;
     --accent-dark-hsl-l: 63%;
 
-    --color-red-rgb: 191, 97, 106;
-    --color-orange-rgb: 208, 135, 112;
-    --color-yellow-light-rgb: 235, 203, 139;
-    --color-yellow-dark-rgb: 228, 184, 96;
-    --color-green-rgb: 163, 190, 140;
-    --color-purple-rgb: 180, 142, 173;
+    --color-red-rgb: rgb(191, 97, 106);
+    --color-orange-rgb: rgb(208, 135, 112);
+    --color-yellow-light-rgb: rgb(235, 203, 139);
+    --color-yellow-dark-rgb: rgb(228, 184, 96);
+    --color-green-rgb: rgb(163, 190, 140);
+    --color-purple-rgb: rgb(180, 142, 173);
     --color-sea-green-rgb: 143, 188, 187;
-    --color-cyan-rgb: 136, 192, 208;
-    --color-frost-rgb: 129, 161, 193;
-    --color-blue-rgb: 94, 129, 172;
-    --color-salmon-rgb: 252, 110, 104;
+    --color-cyan-rgb: rgb(136, 192, 208);
+    --color-frost-rgb: rgb(129, 161, 193);
+    --color-blue-rgb: rgb(94, 129, 172);
+    --color-salmon-rgb: rgb(252, 110, 104);
 
     --b0: #2E3440;
     --b1: #3B4252;
@@ -837,8 +837,8 @@ settings:
     --w2: #ECEFF4;
     --w3: #f5f7f9;
 
-    --w0-rgb: 216, 222, 233;
-    --b3-rgb: 76, 86, 106;
+    --w0-rgb: rgb(216, 222, 233);
+    --b3-rgb: rgb(76, 86, 106);
 
     --text-error: var(--color-salmon);
     --text-accent: var(--color-accent);
@@ -1790,8 +1790,8 @@ body {
 }
 
 .callout {
-    border-top: 4px solid rgba(var(--callout-color), 1.0);
-    border-left: 2px solid rgba(var(--callout-color), 1.0);
+    border-top: 4px solid color-mix(in srgb, var(--callout-color) 100%, transparent);
+    border-left: 2px solid color-mix(in srgb, var(--callout-color) 100%, transparent);
 }
 
 /* make quotes look like callouts too */
@@ -1968,7 +1968,7 @@ div[data-callout*="plain_columns"] {
     /*Red highlighter (edit)*/
     & mark.edit { 
         border-color: var(--color-red);
-        background: rgba(var(--color-red-rgb),0.2);
+        background: color-mix(in srgb, var(--color-red-rgb) 20%, transparent);
     }
     & mark.edit::before {
         color: var(--color-red);
@@ -1978,7 +1978,7 @@ div[data-callout*="plain_columns"] {
     /*Orange highlighter (unfinished)*/
     & mark.unfinished { 
         border-color: var(--color-orange);
-        background: rgba(var(--color-orange-rgb),0.2);
+        background: color-mix(in srgb, var(--color-orange-rgb) 20%, transparent);
     }
     & mark.unfinished::before {
         color: var(--color-orange);
@@ -1988,7 +1988,7 @@ div[data-callout*="plain_columns"] {
     /*Pink highlighter (verify)*/
     & mark.verify { 
         border-color: var(--color-purple);
-        background: rgba(var(--color-purple-rgb),0.2);
+        background: color-mix(in srgb, var(--color-purple-rgb) 20%, transparent);
     }
     & mark.verify::before {
         color: var(--color-purple);
@@ -1998,7 +1998,7 @@ div[data-callout*="plain_columns"] {
     /* Green highlighter (important)*/
     & mark.important { 
         border-color: var(--color-green);
-        background: rgba(var(--color-green-rgb),0.2);
+        background: color-mix(in srgb, var(--color-green-rgb) 20%, transparent);
     }
     & mark.important::before {
         color: var(--color-green);


### PR DESCRIPTION
Hello! I'm [saberzero1](https://github.com/saberzero1), a [community reviewer](https://obsidian.md/help/credits#Community+review) for Obsidian plugins and themes. We're sending this PR out to you proactively to help you prepare for a recent Obsidian update.

## Summary

Obsidian 1.13 changed how `--callout-color` works. It now provides a valid CSS color value (e.g. `rgb(255, 0, 128)`) instead of a bare RGB triplet (`255, 0, 128`).

This breaks two patterns:

**1. Bare RGB triplets in declarations:**
```css
/* Before (broken on 1.13+) */
--callout-color: 255, 0, 128;
/* After */
--callout-color: rgb(255, 0, 128);
```

**2. Wrapping `var(--callout-color)` in `rgb()`/`rgba()`:**
```css
/* Before (produces invalid rgb(rgb(...)) on 1.13+) */
background: rgba(var(--callout-color), 0.1);
/* After */
background: color-mix(in srgb, var(--callout-color) 10%, transparent);
```

## Changes

- Wrapped bare RGB triplets in `--callout-color` declarations with `rgb()`
- Replaced `rgb(var(--callout-color))` with `var(--callout-color)`
- Replaced `rgba(var(--callout-color), <alpha>)` with `color-mix(in srgb, var(--callout-color) <percent>, transparent)`
- Updated `minAppVersion` in `manifest.json` to `1.13.0` (if it was lower)

## Context

See the [Obsidian 1.13 changelog](https://obsidian.md/changelog/) for details on this breaking change.
